### PR TITLE
Add CancellationToken support and repository tests

### DIFF
--- a/LayeredArch.Application/Interfaces/IOrderRepository.cs
+++ b/LayeredArch.Application/Interfaces/IOrderRepository.cs
@@ -9,6 +9,6 @@ public interface IOrderRepository
     // Prefer not to expose domain entities directly from repositories.
     // Instead, return DTOs or read models for queries to avoid accidental
     // Will Change in future to return Order Dto
-    Task AddAsync(Order order);
-    Task<Order?> GetByIdAsync(int id);
+    Task AddAsync(Order order, CancellationToken cancellationToken = default);
+    Task<Order?> GetByIdAsync(int id , CancellationToken cancellationToken = default);
 }

--- a/LayeredArch.Infrastructure/Persistence/OrderRepository.cs
+++ b/LayeredArch.Infrastructure/Persistence/OrderRepository.cs
@@ -10,16 +10,16 @@ public class OrderRepository(ApplicationDbContext context) : IOrderRepository
 
     //Will Use UOW pattern in future
     private readonly ApplicationDbContext _context = context;
-    public async Task AddAsync(Order order)
+    public async Task AddAsync(Order order , CancellationToken cancellationToken = default)
     {
         _context.Orders.Add(order);
-        await _context.SaveChangesAsync();
+        await _context.SaveChangesAsync(cancellationToken);
     }
 
-    public async Task<Order?> GetByIdAsync(int id)
+    public async Task<Order?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
     {
         return await _context.Orders
             .Include(o => o.Items)
-            .FirstOrDefaultAsync(o => o.Id == id);
+            .FirstOrDefaultAsync(o => o.Id == id, cancellationToken);
     }
 }

--- a/LayeredArch.Tests/OrerRepositoryTests.cs
+++ b/LayeredArch.Tests/OrerRepositoryTests.cs
@@ -1,0 +1,104 @@
+﻿
+using LayeredArch.Domain.Entities;
+using LayeredArch.Infrastructure.Persistence;
+
+namespace LayeredArch.Tests;
+
+public class OrerRepositoryTests
+{
+
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnOrder_WhenOrderExists()
+    {
+        //Arrange
+       await using var dbContext = new InMemoryDbContext();
+        var orderRepository = new OrderRepository(dbContext);
+        var customerRepository = new CustomerRepository(dbContext);
+
+
+
+        var customer = new Customer("Moahmed", "Mohamed@gmail.com","0123456789", "Egypt");
+        await customerRepository.AddAsync(customer);
+
+        var customerId = customer.Id;
+
+
+        var order = new Order(customerId);
+        order.AddItem("Product1", 2, 10.0m);
+
+        await orderRepository.AddAsync(order);
+
+        var orderId = order.Id;
+
+        //Act
+        var result = await orderRepository.GetByIdAsync(orderId);
+
+
+        //Assert
+        //The order exists
+        //The items were loaded correctly via Include.
+
+        Assert.NotNull(result);
+        Assert.Equal(orderId, result?.Id);
+        Assert.Single(result!.Items);
+        Assert.Equal("Product1", result.Items[0].Product);
+    }
+    [Fact]
+    public async Task GetByIdAsync_ShouldReturnNull_WhenOrderDoesNotExist()
+    {
+        // Arrange
+        await using var dbContext = new InMemoryDbContext();
+        var orderRepository = new OrderRepository(dbContext);
+
+        var nonExistentOrderId = 999;
+
+        // Act
+        var result = await orderRepository.GetByIdAsync(nonExistentOrderId);
+
+        // Assert
+        Assert.Null(result); 
+    }
+
+
+    [Fact]
+    public async Task AddAsync_ShouldAddOrderSuccessfully()
+    {
+        // Arrange
+       await using var dbContext = new InMemoryDbContext();
+        var orderRepository = new OrderRepository(dbContext);
+        var customerRepository = new CustomerRepository(dbContext);
+
+        var customer = new Customer("Moahmed", "Mohamed@gmail.com", "0123456789", "Egypt");
+        await customerRepository.AddAsync(customer);
+
+        var customerId = customer.Id;
+
+        var order = new Order(customerId);
+
+        order.AddItem("Product1", 2, 10.0m);
+
+        // Act
+        await orderRepository.AddAsync(order);
+
+        // Assert
+        var addedOrder = await orderRepository.GetByIdAsync(order.Id);
+        Assert.NotNull(addedOrder);
+        Assert.Equal(order.Id, addedOrder?.Id);
+        Assert.Equal(customer.Id, addedOrder?.CustomerId);
+        Assert.Single(addedOrder!.Items);
+        Assert.Equal("Product1", addedOrder.Items[0].Product);
+    }
+
+
+    [Fact]
+    public void Constructor_ShouldThrowException_WhenCustomerIdIsInvalid()
+    {
+        // Arrange
+        var invalidCustomerId = -1;
+
+        // Act & Assert
+        var ex = Assert.Throws<ArgumentException>(() => new Order(invalidCustomerId));
+        Assert.Equal("customerId", ex.ParamName);
+    }
+
+}


### PR DESCRIPTION
Updated the `IOrderRepository` interface to include optional `CancellationToken` parameters in `AddAsync` and `GetByIdAsync` methods for improved cancellation handling. Updated the `OrderRepository` implementation to align with these changes.

Added a new test class, `OrerRepositoryTests`, to validate the functionality of `OrderRepository`. Introduced test cases for retrieving existing orders, handling non-existent orders, successfully adding orders, and validating the `Order` constructor with invalid input.

Tests use an in-memory database to ensure isolation and reliability. These changes enhance repository robustness, support for cancellation, and test coverage.