### PR TITLE
Refactor namespaces and add handler tests

### DIFF
--- a/LayeredArch.Application/Orders/CreateOrderHandler.cs
+++ b/LayeredArch.Application/Orders/CreateOrderHandler.cs
@@ -8,14 +8,14 @@ public class CreateOrderHandler(IOrderRepository orderRepository)
 
     private readonly IOrderRepository _orderRepository = orderRepository;
 
-    public async Task<int> HandleAsync(CreateOrderCommand command)
+    public async Task<int> HandleAsync(CreateOrderCommand command,CancellationToken cancellationToken = default)
     {
         var order = new Order(command.CustomerId);
 
         foreach (var item in command.Items)
             order.AddItem(item.Product, item.Quantity, item.Price);
 
-        await _orderRepository.AddAsync(order);
+        await _orderRepository.AddAsync(order,cancellationToken);
         return order.Id;
     }
 

--- a/LayeredArch.Tests/Domains/CustomerTests.cs
+++ b/LayeredArch.Tests/Domains/CustomerTests.cs
@@ -1,6 +1,6 @@
 ﻿using LayeredArch.Domain.Entities;
 
-namespace LayeredArch.Tests;
+namespace LayeredArch.Tests.Domains;
 
 public class CustomerTests
 {

--- a/LayeredArch.Tests/Domains/OrderTests.cs
+++ b/LayeredArch.Tests/Domains/OrderTests.cs
@@ -1,8 +1,6 @@
-﻿
+﻿using LayeredArch.Domain.Entities;
 
-using LayeredArch.Domain.Entities;
-
-namespace LayeredArch.Tests;
+namespace LayeredArch.Tests.Domains;
 
 public class OrderTests
 {

--- a/LayeredArch.Tests/LayeredArch.Tests.csproj
+++ b/LayeredArch.Tests/LayeredArch.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />

--- a/LayeredArch.Tests/OrderHandlers/CreateOrderHandlerTests.cs
+++ b/LayeredArch.Tests/OrderHandlers/CreateOrderHandlerTests.cs
@@ -1,0 +1,67 @@
+﻿
+using FakeItEasy;
+using LayeredArch.Application.Interfaces;
+using LayeredArch.Application.Orders;
+using LayeredArch.Domain.Entities;
+namespace LayeredArch.Tests.OrderHandlers;
+
+public class CreateOrderHandlerTests
+{
+
+    [Fact]
+    public async Task HandleAsync_ShouldReturnOrderId_WhenOrderCreatedSuccssfully()
+    {
+        //Arrange
+        var fakedOrderRepository = A.Fake<IOrderRepository>();
+
+        A.CallTo(() => fakedOrderRepository.AddAsync(A<Order>._, A<CancellationToken>._))
+            .Invokes((Order o, CancellationToken _) =>
+            {
+                 o.GetType()
+                .GetProperty(nameof(o.Id))!
+                .SetValue(o, 1);
+            }).Returns(Task.CompletedTask);
+
+
+        var command = new CreateOrderCommand
+        {
+            CustomerId = 20,
+            Items =
+            [
+                new(){Product ="Keyboard",Quantity = 2 , Price = 50m},
+                new(){Product ="Mouse",Quantity = 5 , Price = 100m},
+                new(){Product ="Screen",Quantity = 2 , Price = 1000m},
+            ]
+        };
+
+        var sut = new CreateOrderHandler(fakedOrderRepository);
+
+        //Act
+
+        var result = await sut.HandleAsync(command);
+
+
+        //Assert
+        A.CallTo(() => fakedOrderRepository.AddAsync(A<Order>._, A<CancellationToken>._))
+            .MustHaveHappenedOnceExactly();
+
+        Assert.Equal(1, result);
+    }
+
+    [Fact]
+    public async Task HandleAsync_ShouldThrowException_WhenCustomerIdIsInvalid()
+    {
+        // Arrange
+        var fakedOrderRepository = A.Fake<IOrderRepository>();
+        var sut = new CreateOrderHandler(fakedOrderRepository);
+
+        var invalidCommand = new CreateOrderCommand
+        {
+            CustomerId = -5,
+            Items = []
+        };
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => sut.HandleAsync(invalidCommand));
+    }
+}

--- a/LayeredArch.Tests/OrderHandlers/GetOrderByIdHandlerTest.cs
+++ b/LayeredArch.Tests/OrderHandlers/GetOrderByIdHandlerTest.cs
@@ -1,0 +1,83 @@
+﻿
+using LayeredArch.Application.Orders;
+using LayeredArch.Domain.Entities;
+using FakeItEasy;
+using LayeredArch.Application.Interfaces;
+
+namespace LayeredArch.Tests.OrderHandlers;
+
+public class GetOrderByIdHandlerTest
+{
+
+   
+    [Fact]
+    public async Task HandleAsync_ShouldReturnOrderDto_WhenOrderIdIsExists()
+    {
+        //Arrange
+        var orderRepository = A.Fake<IOrderRepository>();
+        var handler = new GetOrderByIdHandler(orderRepository);
+
+        //Must add a customer first because of the foreign key constraint
+        var customer = new Customer("Omer","Omer@gmail.com","0123456789","Egypt");
+
+        typeof(Customer).GetProperty(nameof(Customer.Id))!
+            .SetValue(customer, 1);
+
+        //Must add an order first to be able to get it and pass customerId to it
+        var order = new Order(customer.Id);
+
+        typeof(Order).GetProperty(nameof(Order.Id))!.SetValue(order, 1);
+
+        typeof(Order).GetProperty(nameof(Order.Customer))!.SetValue(order, customer);
+
+        order.AddItem("Laptop", 1, 1200m);
+
+
+        var query = new GetOrderByIdQuery(order.Id);
+
+        A.CallTo(() => orderRepository.GetByIdAsync(query.Id, A<CancellationToken>._))
+            .Returns(Task.FromResult<Order?>(order));
+
+
+        //Act
+        var result = await handler.HandleAsync(query);
+
+        //Assert
+        AssertOrderDtoMatches(result, customer, order);
+    }
+
+
+    [Fact]
+    public async Task HandleAsync_ShouldReturnNull_WhenOrderDoesNotExist()
+    {
+        //Arrange
+        var orderRepository = A.Fake<IOrderRepository>();
+
+        var handler = new GetOrderByIdHandler(orderRepository);
+
+        var query = new GetOrderByIdQuery(1);
+
+        A.CallTo(() => orderRepository.GetByIdAsync(query.Id, A<CancellationToken>._))
+            .Returns(Task.FromResult<Order?>(null));
+
+        //Act
+        var result = await handler.HandleAsync(query);
+
+        //Assert
+        Assert.Null(result);
+    }
+
+
+
+    private static void AssertOrderDtoMatches(OrderDto? result , Customer expectedCustomer, Order expectedOrder)
+    {
+        Assert.NotNull(result);
+        Assert.Equal(expectedOrder.Id, result?.Id);
+        Assert.Equal(expectedCustomer.Id, result?.Customer.Id);
+        Assert.Equal(expectedCustomer.Name, result?.Customer.Name);
+        Assert.Equal(expectedCustomer.Phone, result?.Customer.Phone);
+        Assert.Equal(expectedCustomer.Email, result?.Customer.Email);
+        Assert.Equal(expectedCustomer.Address, result?.Customer.Address);
+        Assert.Equal(expectedOrder.Items.Count, result!.Items.Count);
+    }
+}

--- a/LayeredArch.Tests/Repositories/CustomerRepositoryTests.cs
+++ b/LayeredArch.Tests/Repositories/CustomerRepositoryTests.cs
@@ -1,9 +1,8 @@
-﻿
-using LayeredArch.Domain.Entities;
+﻿using LayeredArch.Domain.Entities;
 using LayeredArch.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
-namespace LayeredArch.Tests;
+namespace LayeredArch.Tests.Repositories;
 
 public class CustomerRepositoryTests
 {

--- a/LayeredArch.Tests/Repositories/OrderRepositoryTests.cs
+++ b/LayeredArch.Tests/Repositories/OrderRepositoryTests.cs
@@ -1,10 +1,9 @@
-﻿
-using LayeredArch.Domain.Entities;
+﻿using LayeredArch.Domain.Entities;
 using LayeredArch.Infrastructure.Persistence;
 
-namespace LayeredArch.Tests;
+namespace LayeredArch.Tests.Repositories;
 
-public class OrerRepositoryTests
+public class OrderRepositoryTests
 {
 
     [Fact]


### PR DESCRIPTION
Refactored namespaces in test files for better organization. Updated `CreateOrderHandler` to support `CancellationToken`. Added `CreateOrderHandlerTests` and `GetOrderByIdHandlerTest` to validate handler functionality. Introduced `FakeItEasy` dependency for mocking. Fixed a typo in `OrderRepositoryTests`.